### PR TITLE
Update to latest OBv3 contexts, from beta through 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # security-document-loader Changelog
 
+## 3.0.0 -
+### Changed
+- **BREAKING**: Now includes OBv3 contexts from beta to 3.0.2
+
 ## 2.0.0 - 2023-05-17
 ### Changed
 - **Breaking**: Update OpenBadges v3 context to `v1.0.0`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSON-LD Document Loader _(@digitalcredentials/security-document-loader)_
 
-[![Build status](https://img.shields.io/github/workflow/status/digitalcredentials/security-document-loader/Node.js%20CI)](https://github.com/digitalcredentials/security-document-loader/actions?query=workflow%3A%22Node.js+CI%22)
+[![Build status](https://img.shields.io/github/actions/workflow/status/digitalcredentials/security-document-loader/main.yml?branch=main)](https://github.com/digitalcredentials/security-document-loader/actions?query=workflow%3A%22Node.js+CI%22)
 [![NPM Version](https://img.shields.io/npm/v/@digitalcredentials/security-document-loader.svg)](https://npm.im/@digitalcredentials/security-document-loader)
 
 > A secure and convenient JSON-LD document loader.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Example Isomorphic TS/JS Lib Template _(@digitalcredentials/security-document-loader)_
+# JSON-LD Document Loader _(@digitalcredentials/security-document-loader)_
 
 [![Build status](https://img.shields.io/github/workflow/status/digitalcredentials/security-document-loader/Node.js%20CI)](https://github.com/digitalcredentials/security-document-loader/actions?query=workflow%3A%22Node.js+CI%22)
 [![NPM Version](https://img.shields.io/npm/v/@digitalcredentials/security-document-loader.svg)](https://npm.im/@digitalcredentials/security-document-loader)
 
-> A Typescript/Javascript isomorphic library template, for use in the browser, Node.js, and React Native.
+> A secure and convenient JSON-LD document loader.
 
 ## Table of Contents
 
@@ -70,11 +70,61 @@ loader.addStatic('https://example.com/my-context/v1', contextObject)
 const documentLoader = loader.build()
 ```
 
+### Fetching From the Web
 To enable fetching arbitrary contexts from the web (not recommended, if you can
 avoid it):
 
 ```js
 const documentLoader = securityLoader({ fetchRemoteContexts: true }).build()
+```
+
+### Supported URL Protocol Handlers
+
+Out of the box, this library supports loading the following documents:
+
+* Explicitly added URLs from static local caches (that is, ones that you 
+  explicitly add via `loader.addStatic`)
+* DID Documents using the `did:key` and `did:web` methods.
+
+Additionally, if your use case allows it, you can enable `fetchRemoteContexts`, 
+which will add support for URLs using the `http` and `https` protocols (see 
+previous section).
+
+#### Adding Custom Protocol Handlers
+Sometimes you will need to add documents with other URL protocols. If you have
+internal code to resolve those protocols (for example, you can fetch some
+`urn:` documents from a local database), you can write a custom protocol
+handler:
+
+```js
+import { securityLoader } from '@digitalcredentials/security-document-loader'
+
+function getDocument (url) {
+  // Some internal function that fetches or creates documents
+}
+
+const customResolver = {
+  /**
+   * @param {object} options - Options hashmap.
+   * @param {string} options.url - Document URL (here `urn:...` key id)
+   * @returns {Promise<object>} - Resolves with key object document.
+   */
+  async get(params: Record<string, string>): Promise<unknown> {
+    let document
+    try {
+      document = await getDocument(params.url)
+    } catch(e) {
+      throw new Error('NotFoundError')
+    }
+
+    return document
+  }
+};
+
+// For example, use your `getDocument` function to resolve all `urn:` URIs:
+securityLoader.setProtocolHandler({protocol: 'urn', handler: customResolver})
+
+const documentLoader = securityLoader().build()
 ```
 
 ## Contribute

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@digitalcredentials/did-io": "^1.0.2",
     "@digitalcredentials/did-method-key": "^2.0.3",
     "@digitalcredentials/ed25519-verification-key-2020": "^3.2.2",
-    "@digitalcredentials/open-badges-context": "^1.0.0",
+    "@digitalcredentials/open-badges-context": "^2.0.1",
     "@digitalcredentials/x25519-key-agreement-key-2020": "^3.0.0",
     "@interop/did-web-resolver": "^3.0.0",
     "credentials-context": "^2.0.0",

--- a/src/documentLoader.ts
+++ b/src/documentLoader.ts
@@ -108,10 +108,10 @@ export function securityLoader({ fetchRemoteContexts = false }: SecurityLoaderPa
 
   loader.addStatic(vcStatusListCtx.CONTEXT_URL_V1, vcStatusListCtx.CONTEXT_V1);
 
-  // Open Badges v3 Context (with multiple URL aliases)
-  loader.addStatic(obCtx.CONTEXT_URL_V3, obCtx.CONTEXT_V3)
-  loader.addStatic(obCtx.CONTEXT_URL_V3_JFF_V1, obCtx.CONTEXT_V3)
-  loader.addStatic(obCtx.CONTEXT_URL_V3_IMS, obCtx.CONTEXT_V3)
+  // Open Badges v3 Contexts, includes OBv3 Beta, 3.0, 3.0.1, 3.0.2, etc.
+  for (const [url, contextBody] of obCtx.contexts) {
+    loader.addStatic(url, contextBody)
+  }
 
   loader.setDidResolver(resolver);
 

--- a/test/documentLoader.spec.ts
+++ b/test/documentLoader.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { httpClientHandler, securityLoader } from "../src";
+import { httpClientHandler, securityLoader } from '../src';
 
 describe('documentLoader', () => {
   it('should load a document', async () => {


### PR DESCRIPTION
Partially addresses issues https://github.com/digitalcredentials/web-verifier-plus/issues/72 and https://github.com/digitalcredentials/security-document-loader/issues/2