### PR TITLE
handle JSON response outside http-client

### DIFF
--- a/src/documentLoader.ts
+++ b/src/documentLoader.ts
@@ -54,7 +54,7 @@ export const httpClientHandler = {
         'Cache-Control': 'no-cache',
         'Pragma': 'no-cache'
       };
-      result = await httpClient.get(params.url, { headers });
+      result = await httpClient.get(params.url, { headers, parseBody: false });
     } catch(e: any) {
       throw new Error(`NotFoundError loading "${params.url}": ${e.message}`);
     }

--- a/test/documentLoader.spec.ts
+++ b/test/documentLoader.spec.ts
@@ -24,6 +24,14 @@ describe('documentLoader', () => {
       .equal('did:key:z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC');
   });
 
+  it('should load v2 context from web', async () => {
+    const documentLoader = securityLoader({fetchRemoteContexts: true}).build();
+
+    const url = 'https://www.w3.org/ns/credentials/v2';
+    const result = await documentLoader(url);
+    expect(result.document).to.exist;
+  });
+
   it('supports beta OBv3 context', async () => {
     const load = securityLoader().build()
     const { document } = await load('https://purl.imsglobal.org/spec/ob/v3p0/context.json')


### PR DESCRIPTION
Closes #13 

Pass `parseBody: false` to http-client; add test that remote-loads a context document with `Content-Type: application/ld+json`. 

Current test that fetches https://digitalcredentials.github.io/credential-status-playground/JWZM3H8WKU did not catch this bug because the response type from GitHub pages for an extensionless file is `applicaton/octet-stream` which does not cause the http-client to parse the body.


