### PR TITLE
add types to package.json exports["."]

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/esm/index.js"
+      "import": "./dist/esm/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Fixes an error when imported in a ts project  using
```
    "module": "NodeNext",
    "moduleResolution": "NodeNext",
```

